### PR TITLE
Automatic Firestore backup on production project

### DIFF
--- a/.firebase/storage.rules
+++ b/.firebase/storage.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/.github/workflows/backup-production.yml
+++ b/.github/workflows/backup-production.yml
@@ -1,5 +1,7 @@
 name: production
-on: push
+on:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   backup:

--- a/.github/workflows/backup-production.yml
+++ b/.github/workflows/backup-production.yml
@@ -1,11 +1,11 @@
-name: production
+name: backup
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 8 * * *"
 
 jobs:
   backup:
-    name: backup-firestore
+    name: production-firestore
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/backup-production.yml
+++ b/.github/workflows/backup-production.yml
@@ -1,0 +1,14 @@
+name: production
+on: push
+
+jobs:
+  backup:
+    name: backup-firestore
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          project_id: cusec-2021-production
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+      - run: gcloud firestore export gs://cusec-2021-production-backup

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy -P production --only hosting,firestore
+          args: deploy -P production --only hosting,firestore,storage
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -39,6 +39,6 @@ jobs:
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy -P staging --only hosting,firestore
+          args: deploy -P staging --only hosting,firestore,storage
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/firebase.json
+++ b/firebase.json
@@ -16,5 +16,8 @@
   "firestore": {
     "rules": ".firebase/firestore.rules",
     "indexes": ".firebase/firestore.indexes.json"
+  },
+  "storage": {
+    "rules": ".firebase/storage.rules"
   }
 }


### PR DESCRIPTION
Resolves #30 and only backs the **production** Firestore project daily.

It ran it once successfully when it was temporarily set to run on push, before it was updated to a cron schedule to run at midnight UTC. I wanted to wait for it to run again before making this PR but then I saw [scheduled triggers only run on the base/default branch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events), which is `develop` for us.

I followed the [Export and import data](https://firebase.google.com/docs/firestore/manage-data/export-import) guide for Firestore. I made a new service account to use with the minimum `Cloud Datastore Import Export Admin` and `Storage Admin` roles required.

Something to look out for is with billing as the number of users grow.

> Caution: Exporting data from Cloud Firestore will incur one read operation per document exported. However, these reads will not appear in the usage section of the console. Make sure you understand this before setting up recurring exports to avoid an unexpected bill.

I think we should be fine since even if we had 10,000 users who all joined the email listing and registered for the event (when it's ready) on the same day, we still would stay under the free tier.

It'd also take up relatively little storage space. There should be plenty and we could always make backups less frequent if needed before we shut it down after registration or the event is over.