### PR TITLE
Fix small social icons

### DIFF
--- a/components/Socials.tsx
+++ b/components/Socials.tsx
@@ -1,5 +1,4 @@
 import { ReactElement } from "react";
-import styled from "@emotion/styled";
 import { Link } from "@chakra-ui/core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -8,10 +7,6 @@ import {
   faTwitterSquare,
 } from "@fortawesome/free-brands-svg-icons";
 import useStore from "../src/store";
-
-const StyledIcon = styled(FontAwesomeIcon)`
-  width: 20px;
-`;
 
 interface PropTypes {
   [prop: string]: string;
@@ -39,7 +34,7 @@ export default function Socials(props: PropTypes): ReactElement {
           clickSocial("facebook");
         }}
       >
-        <StyledIcon icon={faFacebookSquare} />
+        <FontAwesomeIcon width="20px" icon={faFacebookSquare} />
       </Link>
       <Link
         {...props}
@@ -50,7 +45,7 @@ export default function Socials(props: PropTypes): ReactElement {
           clickSocial("twitter");
         }}
       >
-        <StyledIcon icon={faTwitterSquare} />
+        <FontAwesomeIcon width="20px" icon={faTwitterSquare} />
       </Link>
       <Link
         {...props}
@@ -61,7 +56,7 @@ export default function Socials(props: PropTypes): ReactElement {
           clickSocial("instagram");
         }}
       >
-        <StyledIcon icon={faInstagram} />
+        <FontAwesomeIcon width="20px" icon={faInstagram} />
       </Link>
     </>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -32,6 +32,9 @@ function App({ Component, pageProps }: AppProps): ReactElement {
   return (
     <>
       <Head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
         <link
           href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
           rel="stylesheet"

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -6,8 +6,6 @@ export default function Email(): ReactElement {
     <>
       <Head>
         <title>CUSEC 2021 Email Signature</title>
-        <link rel="icon" href="/favicon.ico" />
-        <meta charSet="UTF-8" />
       </Head>
 
       <table id="email-signature">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,9 +11,6 @@ export default function Home(): React.ReactElement {
     <div className="container">
       <Head>
         <title>CUSEC 2021</title>
-        <link rel="icon" href="/favicon.ico" />
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
           name="description"
           content="Mark your calendars, Canada's favourite conference is back virtually this winter! Join us January 9-10, 2021 for a weekend of amazing speakers, workshops, and more!"


### PR DESCRIPTION
Resolves #31 

Small fix -- one of my commits before had an unexpected side-effect of making the social icons in the hero small (see issue for more detail).

I fixed it by setting the width on fontawesome icons though its `width` prop instead of using `emotion/styled`. I'm not sure why the issue only popped up after the refactoring in the past commit.

Notice the small social icons in the 'before' versus the restored larger size in the 'after' at the top-right of the screenshots (taken in Firefox):

### Before

![image](https://user-images.githubusercontent.com/20251243/92874774-59996f00-f3d6-11ea-815d-ccac9d25338a.png)

### After

![image](https://user-images.githubusercontent.com/20251243/92874828-661dc780-f3d6-11ea-80e2-1a924b785866.png)

---

Mobile has the same difference also.