### PR TITLE
Fix small social icons (again)

### DIFF
--- a/components/NavOverlay.tsx
+++ b/components/NavOverlay.tsx
@@ -23,7 +23,7 @@ export default function NavOverlay(props: {
       transition="opacity 0.4s, visibility 0.4s"
       position="fixed"
       width="100%"
-      height="100%"
+      height="100vh"
       zIndex={10}
       direction="column"
       align="center"

--- a/components/Socials.tsx
+++ b/components/Socials.tsx
@@ -6,6 +6,12 @@ import {
 } from "@fortawesome/free-brands-svg-icons";
 import React, { ReactElement } from "react";
 import SocialLink from "@/components/SocialLink";
+import styled from "@emotion/styled";
+
+const StyledIcon = styled(FontAwesomeIcon)`
+  width: 20px !important;
+  height: auto;
+`;
 
 interface PropTypes {
   [prop: string]: string;
@@ -19,21 +25,21 @@ export default function Socials(props: PropTypes): ReactElement {
         eventType="facebook"
         href="https://www.facebook.com/cusecofficial/"
       >
-        <FontAwesomeIcon width="20px" icon={faFacebookSquare} />
+        <StyledIcon icon={faFacebookSquare} />
       </SocialLink>
       <SocialLink
         {...props}
         eventType="twitter"
         href="https://twitter.com/cusec"
       >
-        <FontAwesomeIcon width="20px" icon={faTwitterSquare} />
+        <StyledIcon icon={faTwitterSquare} />
       </SocialLink>
       <SocialLink
         {...props}
         eventType="instagram"
         href="https://www.instagram.com/cusecofficial/"
       >
-        <FontAwesomeIcon width="20px" icon={faInstagram} />
+        <StyledIcon icon={faInstagram} />
       </SocialLink>
     </>
   );


### PR DESCRIPTION
The fortawesome SVGs have some built-in classes/styles applied to them which set the width to a small value, which this PR overrides to a custom value. I'm not sure why it suddenly showed up again after updating Next :shrug: 

Resolves #59 