### PR TITLE
fix adding additional router events on re-render

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -15,6 +15,7 @@ function App({ Component, pageProps }: AppProps): ReactElement {
   useEffect(() => {
     if (analytics) {
       Router.events.on("routeChangeComplete", (url) => {
+        window.scrollTo(0, 0);
         analytics.logEvent(`routeChangeComplete: ${url}`);
       });
       Router.events.on("hashChangeComplete", (url) =>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,17 +13,17 @@ function App({ Component, pageProps }: AppProps): ReactElement {
   const initAnalytics = useStore((state) => state.initAnalytics);
 
   useEffect(() => {
-    initAnalytics();
-  }, [initAnalytics]);
-
-  if (analytics) {
-    Router.events.on("routeChangeComplete", (url) =>
-      analytics.logEvent(`routeChangeComplete: ${url}`)
-    );
-    Router.events.on("hashChangeComplete", (url) =>
-      analytics.logEvent(`hashChangeComplete: ${url}`)
-    );
-  }
+    if (analytics) {
+      Router.events.on("routeChangeComplete", (url) => {
+        analytics.logEvent(`routeChangeComplete: ${url}`);
+      });
+      Router.events.on("hashChangeComplete", (url) =>
+        analytics.logEvent(`hashChangeComplete: ${url}`)
+      );
+    } else {
+      initAnalytics();
+    }
+  }, [analytics, initAnalytics]);
 
   return (
     <>


### PR DESCRIPTION
Noticed that these router events are added on each re-render and accumulate over time. This PR moves it into the useEffect hook where it will run once after analytics is initialized.

This also adds (immediately) scrolling to the top of the page after a route change. Previously if you were scrolled down from the top and switched pages, the new page would also be partially scrolled down.