### PR TITLE
feat: add a bottom banner to promote HackaComm better

### DIFF
--- a/components/core/Text.tsx
+++ b/components/core/Text.tsx
@@ -45,6 +45,16 @@ export const LinkPrimary = styled(Link)`
   }
 `;
 
+export const LinkSecondary = styled(Link)`
+  font-weight: bold;
+  font-size: 16px;
+  color: ${theme.colors.brand.teal};
+
+  &:hover {
+    color: ${theme.colors.brand.blue};
+  }
+`;
+
 export const LinkPrimaryVariant = styled(Link)`
   font-weight: bold;
   font-size: 16px;

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Box, Flex, Text } from "@chakra-ui/core";
+import { Box, CloseButton, Flex, Text, useToast } from "@chakra-ui/core";
 import styled from "@emotion/styled";
 import Socials from "@/components/Socials";
 import Logo from "../svgs/logo.svg";
@@ -10,12 +10,11 @@ import {
   Body,
   BodyPrimary,
   Headline,
-  Link as ToastLink,
   LinkPrimary,
+  LinkSecondary,
 } from "@/components/core/Text";
 import { ButtonPrimary } from "@/components/core/Button";
 import { WidthWrapper } from "@/components/core/Layout";
-import { useToast, CloseButton } from "@chakra-ui/core";
 import { useRouter } from "next/router";
 
 const minHeights = [750, 750, 800];
@@ -26,6 +25,12 @@ const FlexFullView = styled(Flex)`
   background-attachment: local;
   background-size: 100vw auto;
   background-position: center bottom;
+`;
+
+const HackaCommToast = styled(Flex)`
+  background: black;
+  color: white;
+  border-radius: 15px 15px 0 0;
 `;
 
 export default function Hero(): React.ReactElement {
@@ -80,17 +85,18 @@ export default function Hero(): React.ReactElement {
 
           return (
             <>
-              <Flex color="white" p={3} bg="black">
+              <HackaCommToast p={3}>
                 <Box>
-                  <ToastLink
+                  Check out HackaComm: a brand-new hackathon brought to you by
+                  CUSEC and RBC!{" "}
+                  <LinkSecondary
                     onClick={() => {
                       handlePageSwitch("/hackacomm");
                       closeToasts();
                     }}
                   >
-                    Check out HackaComm: a brand-new hackathon brought to you by
-                    CUSEC and RBC!
-                  </ToastLink>
+                    Click to learn more.
+                  </LinkSecondary>
                 </Box>
                 <Box alignSelf="center">
                   <CloseButton
@@ -101,7 +107,7 @@ export default function Hero(): React.ReactElement {
                     }}
                   />
                 </Box>
-              </Flex>
+              </HackaCommToast>
             </>
           );
         },

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import Link from "next/link";
-import { Flex, Text } from "@chakra-ui/core";
+import { Box, Flex, Text } from "@chakra-ui/core";
 import styled from "@emotion/styled";
 import Socials from "@/components/Socials";
 import Logo from "../svgs/logo.svg";
@@ -10,10 +10,13 @@ import {
   Body,
   BodyPrimary,
   Headline,
+  Link as ToastLink,
   LinkPrimary,
 } from "@/components/core/Text";
 import { ButtonPrimary } from "@/components/core/Button";
 import { WidthWrapper } from "@/components/core/Layout";
+import { useToast, CloseButton } from "@chakra-ui/core";
+import { useRouter } from "next/router";
 
 const minHeights = [750, 750, 800];
 
@@ -32,6 +35,15 @@ export default function Hero(): React.ReactElement {
   const actualWidth = useScreenWidth();
   const [currentWidth, setCurrentWidth] = useState(0);
   const setNavOverlayOpen = useStore((state) => state.setNavOverlayOpen);
+  const toast = useToast();
+  const router = useRouter();
+
+  const toastRefs = useRef<(() => void)[]>([]);
+
+  const closeToasts = () => {
+    toastRefs.current.forEach((cb) => cb());
+    toastRefs.current = [];
+  };
 
   useEffect(() => {
     const updateHeight = () => {
@@ -48,6 +60,56 @@ export default function Hero(): React.ReactElement {
       setNavOverlayOpen(false);
     }
   }, [actualWidth, currentWidth, setNavOverlayOpen]);
+
+  useEffect(() => {
+    const handlePageSwitch = (route: string) => {
+      if (router.pathname !== route) {
+        router.push(route);
+      } else {
+        setNavOverlayOpen(false);
+      }
+    };
+
+    const hackaCommToast = setTimeout(() => {
+      toast({
+        position: "bottom",
+        duration: null,
+        isClosable: true,
+        render: ({ onClose }) => {
+          toastRefs.current.push(onClose);
+
+          return (
+            <>
+              <Flex color="white" p={3} bg="black">
+                <Box>
+                  <ToastLink
+                    onClick={() => {
+                      handlePageSwitch("/hackacomm");
+                      closeToasts();
+                    }}
+                  >
+                    Check out HackaComm: a brand-new hackathon brought to you by
+                    CUSEC and RBC!
+                  </ToastLink>
+                </Box>
+                <Box alignSelf="center">
+                  <CloseButton
+                    size="lg"
+                    _focus={{}}
+                    onClick={() => {
+                      closeToasts();
+                    }}
+                  />
+                </Box>
+              </Flex>
+            </>
+          );
+        },
+      });
+    }, 1000);
+
+    return () => clearTimeout(hackaCommToast);
+  }, [router, setNavOverlayOpen, toast]);
 
   return (
     <FlexFullView


### PR DESCRIPTION
In the screenshot posted in the issue, the banner takes the whole width on a desktop view. I opted against because I didn't want it to cover our cityscape svg. Let me know if you think differently!

Let me know if add link styling and what kind as well. Perhaps a different banner background colour as well?

Edit: Or round top corners?

closes #89