### PR TITLE
fix: close toasts on component dismount

### DIFF
--- a/components/TopBar.tsx
+++ b/components/TopBar.tsx
@@ -59,8 +59,12 @@ export default function TopBar(): React.ReactElement {
   };
 
   const handleCusecIconClick = () => {
-    router.push("/");
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    if (router.pathname !== "/") {
+      router.push("/");
+    } else {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+
     setNavOverlayOpen(false);
   };
 

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -114,7 +114,10 @@ export default function Hero(): React.ReactElement {
       });
     }, 1000);
 
-    return () => clearTimeout(hackaCommToast);
+    return () => {
+      clearTimeout(hackaCommToast);
+      closeToasts();
+    };
   }, [router, setNavOverlayOpen, toast]);
 
   return (


### PR DESCRIPTION
There's an issue with the toast persisting on route changes. It stays there when switching to the main register page (`/register`) and the Hackacomm page (`/hackacomm`) for example. It can also stack multiple times if not dismissed.

- close toasts on component dismount
- avoid unnecessarily pushing to router on main icon click
  - this avoids wasted re-render and lets the smooth scroll work on main page again